### PR TITLE
Replace double slash operator with torch.div.

### DIFF
--- a/UniXcoder/unixcoder.py
+++ b/UniXcoder/unixcoder.py
@@ -196,7 +196,7 @@ class Beam(object):
 
         # bestScoresId is flattened beam x word array, so calculate which
         # word and beam each score came from
-        prevK = bestScoresId // numWords
+        prevK = torch.div(bestScoresId, numWords, rounding_mode="floor")
         self.prevKs.append(prevK)
         self.nextYs.append((bestScoresId - prevK * numWords))
 


### PR DESCRIPTION
Hello :wave: 

I propose a quick fix in unixcoder.py.

In the `advance` method of `Beam` class, the double slash operator is used to do the integer division of `BestScoresId` by `numWords`. It raises a UserWarning with Python 3.10 and torch 1.12.0:
```
unixcoder.py:200: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').
  prevK = bestScoresId // numWords
```
I replaced it with `torch.div` method and `rounding_mode="floor"` argument to reproduce the same result while avoiding the warning.

Have a good day,