### PR TITLE
eos_token at the end of sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Here, we give an example to obtain embedding from CodeBERT.
 ['return', 'Ġmaximum', 'Ġvalue']
 >>> code_tokens=tokenizer.tokenize("def max(a,b): if a>b: return a else return b")
 ['def', 'Ġmax', '(', 'a', ',', 'b', '):', 'Ġif', 'Ġa', '>', 'b', ':', 'Ġreturn', 'Ġa', 'Ġelse', 'Ġreturn', 'Ġb']
->>> tokens=[tokenizer.cls_token]+nl_tokens+[tokenizer.sep_token]+code_tokens+[tokenizer.sep_token]
+>>> tokens=[tokenizer.cls_token]+nl_tokens+[tokenizer.sep_token]+code_tokens+[tokenizer.eos_token]
 ['<s>', 'return', 'Ġmaximum', 'Ġvalue', '</s>', 'def', 'Ġmax', '(', 'a', ',', 'b', '):', 'Ġif', 'Ġa', '>', 'b', ':', 'Ġreturn', 'Ġa', 'Ġelse', 'Ġreturn', 'Ġb', '</s>']
 >>> tokens_ids=tokenizer.convert_tokens_to_ids(tokens)
 [0, 30921, 4532, 923, 2, 9232, 19220, 1640, 102, 6, 428, 3256, 114, 10, 15698, 428, 35, 671, 10, 1493, 671, 741, 2]


### PR DESCRIPTION
According to the paper (Section 3.2 - Input Output Representations), "eos_token" is used to mark the end of text and code contents, and "sep_token" is used to separate the text tokens from the code tokens. Corrected and updated the same in the code sample present in README.
Although both "sep_token" and "eos_token" are "\</s>" tokens.